### PR TITLE
feat: add extended level 1 with helpers

### DIFF
--- a/src/level/kit.ts
+++ b/src/level/kit.ts
@@ -1,0 +1,87 @@
+import { k } from "../game";
+
+export type Solid = ReturnType<typeof solid>;
+const PURPLE = k.rgb(80, 76, 120);
+const RED = k.rgb(200, 70, 70);
+const GOLD = k.rgb(255, 220, 0);
+const GREEN = k.rgb(80, 200, 120);
+const DOOR = k.rgb(140, 140, 170);
+
+export function solid(x: number, y: number, w: number, h: number, color = PURPLE) {
+  return k.add([k.pos(x, y), k.area(), k.body({ isStatic: true }), k.color(color.r, color.g, color.b), k.rect(w, h), "solid"]);
+}
+
+export function hazard(x: number, y: number, w: number, h: number) {
+  return k.add([k.pos(x, y), k.area(), k.body({ isStatic: true }), k.color(RED.r, RED.g, RED.b), k.rect(w, h), "hazard"]);
+}
+
+export function coin(x: number, y: number) {
+  return k.add([k.pos(x, y), k.area(), k.circle(4), k.color(GOLD.r, GOLD.g, GOLD.b), "coin"]);
+}
+
+export function checkpoint(x: number, y: number) {
+  return k.add([k.pos(x, y), k.area(), k.rect(8, 16), k.color(GREEN.r, GREEN.g, GREEN.b), "checkpoint"]);
+}
+
+export function exitDoor(x: number, y: number) {
+  return k.add([k.pos(x, y), k.area(), k.rect(16, 24), k.color(DOOR.r, DOOR.g, DOOR.b), "exit"]);
+}
+
+// Simple horizontal moving platform (back-and-forth)
+export function movingPlatform(x: number, y: number, w = 60, h = 10, amp = 40, speed = 1.0) {
+  const p = k.add([
+    k.pos(x, y),
+    k.area(),
+    k.body({ isStatic: true }),
+    k.rect(w, h),
+    k.color(100, 100, 140),
+    "mplatform",
+    { t: 0, amp, speed },
+  ]);
+  k.onUpdate(() => {
+    p.t += k.dt() * p.speed;
+    p.move(Math.sin(p.t) * p.amp, 0);
+  });
+  return p;
+}
+
+// Collapsing platform: shakes, falls, respawns
+export function collapsingPlatform(x: number, y: number, w = 48, h = 10, delay = 0.6, respawn = 2.0) {
+  const make = () =>
+    k.add([
+      k.pos(x, y),
+      k.area(),
+      k.body({ isStatic: true }),
+      k.rect(w, h),
+      k.color(120, 100, 120),
+      "cplatform",
+      { armed: true },
+    ]);
+
+  let plat = make();
+
+  // When player grounds on it, start collapse
+  k.onCollide("player", "cplatform", (plr: any, cp: any) => {
+    if (!cp.armed) return;
+    cp.armed = false;
+    // tiny shake
+    const start = cp.pos.clone();
+    let t = 0;
+    const shake = k.onUpdate(() => {
+      t += k.dt();
+      cp.pos.x = start.x + Math.sin(t * 50) * 1.5;
+    });
+    k.wait(delay, () => {
+      shake.cancel();
+      // drop
+      cp.use(k.body({ isStatic: false }));
+      cp.gravityScale = 2;
+      k.wait(respawn, () => {
+        k.destroy(cp);
+        plat = make();
+      });
+    });
+  });
+
+  return plat;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,12 @@
 import { k } from "./game";
 import level1 from "./scenes/level1";
+import level1_long from "./scenes/level1_long";
 
 k.scene("level1", level1);
+k.scene("level1_long", level1_long);
 k.scene("level2", () => {
   k.add([k.text("Level 2 (WIP)", { size: 24 }), k.pos(120, 100)]);
 });
 
-k.go("level1");
+// Boot into the long level by default for now
+k.go("level1_long");

--- a/src/scenes/level1_long.ts
+++ b/src/scenes/level1_long.ts
@@ -1,0 +1,143 @@
+import { k } from "../game";
+import { spawnPlayer } from "../entities/player";
+import { solid, hazard, coin, checkpoint, exitDoor, movingPlatform, collapsingPlatform } from "../level/kit";
+
+export default function level1_long() {
+  k.setGravity(1200);
+
+  // ---- WORLD SCALE ----
+  // Each "screen" ~ 320px wide. We'll build ~15 screens long (~4800px).
+  const groundY = 200;
+  const screenW = 320;
+  const startX = 120;
+
+  // Player
+  const spawn = k.vec2(startX, groundY - 24);
+  const plr = spawnPlayer(spawn.clone());
+  (plr as any).addTag?.("player"); // in case your player adds tags; tolerated if missing
+
+  // UI
+  let score = 0;
+  let respawn = spawn.clone();
+  const scoreText = k.add([k.text("0"), k.pos(8, 8), k.fixed()]);
+  const heartsUI = k.add([k.text("❤❤❤"), k.pos(8, 18), k.fixed()]);
+
+  // Hearts text updater
+  k.onUpdate(() => {
+    const h = (plr as any).hearts ?? 3;
+    heartsUI.text = "❤".repeat(h) + " ".repeat(Math.max(0, 3 - h));
+  });
+
+  // Camera follow + gentle clamp
+  k.onUpdate(() => {
+    const target = k.vec2(Math.max(160, plr.pos.x), Math.max(90, plr.pos.y));
+    k.camPos(target);
+  });
+
+  // --- SECTION HELPERS ---
+  const ground = (sx: number, tiles: number) => solid(sx, groundY, tiles * 32, 24);
+  const pit = (sx: number, tiles: number) => hazard(sx, groundY, tiles * 32, 24);
+
+  // ====== SECTION 1: Tutorial Grounds (1 screen) ======
+  ground(0, 10);
+  coin(startX + 40, groundY - 40);
+
+  // Small 1-tile hop
+  pit(10 * 32, 1);
+  ground(11 * 32, 4);
+
+  // ====== SECTION 2: Floating Coin Path (~1.5 screens) ======
+  ground(15 * 32, 10);
+  solid(16 * 32 + 24, groundY - 60, 60, 10);
+  coin(16 * 32 + 54, groundY - 80);
+  coin(17 * 32 + 20, groundY - 48);
+  coin(18 * 32 + 10, groundY - 64);
+
+  // First hazard pit
+  pit(25 * 32, 2);
+  ground(27 * 32, 5);
+
+  // ====== SECTION 3: Staggered Platforms (~1.5 screens) ======
+  solid(28 * 32 + 0, groundY - 40, 50, 10);
+  solid(29 * 32 + 10, groundY - 70, 60, 10);
+  solid(30 * 32 + 12, groundY - 100, 70, 10);
+  coin(30 * 32 + 52, groundY - 120);
+  ground(32 * 32, 8);
+
+  // Patroller placeholder area (enemy can be added later)
+
+  // ====== SECTION 4: Double Hazard Gaps (1 screen) ======
+  pit(40 * 32, 2);
+  ground(42 * 32, 2);
+  pit(44 * 32, 2);
+  ground(46 * 32, 6);
+  coin(42 * 32 + 24, groundY - 70);
+
+  // ====== SECTION 5: Moving Platform #1 (~1.5 screens) ======
+  pit(52 * 32, 4);
+  movingPlatform(54 * 32, groundY - 40, 70, 10, 60, 0.9);
+  coin(55 * 32, groundY - 80);
+  ground(56 * 32, 7);
+
+  // ====== SECTION 6: Checkpoint Cliff (1 screen) ======
+  solid(63 * 32, groundY - 32, 48, 10);
+  checkpoint(63 * 32 + 12, groundY - 48);
+  ground(64 * 32, 6);
+
+  // ====== SECTION 7: Vertical Climb (~1.5 screens) ======
+  solid(66 * 32, groundY - 60, 60, 10);
+  solid(67 * 32 + 40, groundY - 90, 60, 10);
+  solid(68 * 32 + 80, groundY - 120, 60, 10);
+  coin(68 * 32 + 110, groundY - 140);
+  ground(70 * 32, 6);
+
+  // ====== SECTION 8: Collapsing Platforms (~1.5 screens) ======
+  pit(76 * 32, 5);
+  collapsingPlatform(77 * 32, groundY - 40, 60, 10);
+  collapsingPlatform(79 * 32 + 10, groundY - 60, 60, 10);
+  coin(78 * 32 + 20, groundY - 90);
+  ground(81 * 32, 6);
+
+  // ====== SECTION 9: Hazard Gauntlet (~2 screens) ======
+  pit(87 * 32, 3); // wide pit with moving platform
+  movingPlatform(88 * 32, groundY - 50, 70, 10, 80, 1.1);
+  ground(90 * 32, 2);
+  pit(92 * 32, 1);
+  ground(93 * 32, 2);
+  pit(95 * 32, 1);
+  ground(96 * 32, 8);
+  coin(94 * 32, groundY - 70);
+  coin(96 * 32 + 40, groundY - 70);
+
+  // ====== SECTION 10: Victory Run (~2 screens) ======
+  ground(104 * 32, 10);
+  coin(105 * 32, groundY - 48);
+  coin(106 * 32, groundY - 56);
+  const door = exitDoor(113 * 32 + 24, groundY - 24);
+
+  // ----- Collisions / rules -----
+  plr.onCollide("coin", (c: any) => { k.destroy(c); score += 1; scoreText.text = String(score); });
+
+  plr.onCollide("hazard", () => {
+    (plr as any).damage?.(1);
+    k.shake(2);
+  });
+
+  plr.onCollide("checkpoint", (f: any) => {
+    respawn = f.pos.clone();
+  });
+
+  // Basic respawn when hearts hit 0
+  k.onUpdate(() => {
+    const hearts = (plr as any).getHearts?.() ?? 3;
+    if (hearts <= 0) {
+      k.wait(0.05, () => {
+        plr.pos = respawn.clone();
+        (plr as any).hearts = 3;
+        plr.vel = k.vec2(0, 0);
+      });
+    }
+  });
+
+  plr.onCollide("exit", () => k.go("level2"));
+}


### PR DESCRIPTION
## Summary
- build level kit utilities for solids, hazards, collectibles, checkpoints, exits, moving and collapsing platforms
- add long Level 1 scene spanning ~15 screens with 10 themed sections
- wire new scene in main.ts and boot into it

## Testing
- `npm run build` *(fails: sh: 1: vite: Permission denied)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6897781caeac8320b1abd37869ccdd0d