### PR TITLE
Fix player spawning through floor by ordering colliders correctly

### DIFF
--- a/src/entities/player.ts
+++ b/src/entities/player.ts
@@ -17,11 +17,11 @@ export function spawnPlayer(p: Vec2 = k.vec2(64, 0)) {
 
   const plr = k.add([
     k.pos(p.x, p.y - 1),
-    k.area(),
     k.anchor("center"),
+    k.rect(14, 16),
+    k.area(),
     k.body({ jumpForce: JUMP }),
     k.color(230, 230, 255),
-    k.rect(14, 16),
     k.opacity(1),
     { hearts },
   ]);

--- a/src/level/kit.ts
+++ b/src/level/kit.ts
@@ -8,32 +8,64 @@ const GREEN = k.rgb(80, 200, 120);
 const DOOR = k.rgb(140, 140, 170);
 
 export function solid(x: number, y: number, w: number, h: number, color = PURPLE) {
-  return k.add([k.pos(x, y), k.area(), k.body({ isStatic: true }), k.color(color.r, color.g, color.b), k.rect(w, h), "solid"]);
+  return k.add([
+    k.pos(x, y),
+    k.rect(w, h),
+    k.area(),
+    k.body({ isStatic: true }),
+    k.color(color.r, color.g, color.b),
+    "solid",
+  ]);
 }
 
 export function hazard(x: number, y: number, w: number, h: number) {
-  return k.add([k.pos(x, y), k.area(), k.body({ isStatic: true }), k.color(RED.r, RED.g, RED.b), k.rect(w, h), "hazard"]);
+  return k.add([
+    k.pos(x, y),
+    k.rect(w, h),
+    k.area(),
+    k.body({ isStatic: true }),
+    k.color(RED.r, RED.g, RED.b),
+    "hazard",
+  ]);
 }
 
 export function coin(x: number, y: number) {
-  return k.add([k.pos(x, y), k.area(), k.circle(4), k.color(GOLD.r, GOLD.g, GOLD.b), "coin"]);
+  return k.add([
+    k.pos(x, y),
+    k.circle(4),
+    k.area(),
+    k.color(GOLD.r, GOLD.g, GOLD.b),
+    "coin",
+  ]);
 }
 
 export function checkpoint(x: number, y: number) {
-  return k.add([k.pos(x, y), k.area(), k.rect(8, 16), k.color(GREEN.r, GREEN.g, GREEN.b), "checkpoint"]);
+  return k.add([
+    k.pos(x, y),
+    k.rect(8, 16),
+    k.area(),
+    k.color(GREEN.r, GREEN.g, GREEN.b),
+    "checkpoint",
+  ]);
 }
 
 export function exitDoor(x: number, y: number) {
-  return k.add([k.pos(x, y), k.area(), k.rect(16, 24), k.color(DOOR.r, DOOR.g, DOOR.b), "exit"]);
+  return k.add([
+    k.pos(x, y),
+    k.rect(16, 24),
+    k.area(),
+    k.color(DOOR.r, DOOR.g, DOOR.b),
+    "exit",
+  ]);
 }
 
 // Simple horizontal moving platform (back-and-forth)
 export function movingPlatform(x: number, y: number, w = 60, h = 10, amp = 40, speed = 1.0) {
   const p = k.add([
     k.pos(x, y),
+    k.rect(w, h),
     k.area(),
     k.body({ isStatic: true }),
-    k.rect(w, h),
     k.color(100, 100, 140),
     "mplatform",
     { t: 0, amp, speed },
@@ -50,9 +82,9 @@ export function collapsingPlatform(x: number, y: number, w = 48, h = 10, delay =
   const make = () =>
     k.add([
       k.pos(x, y),
+      k.rect(w, h),
       k.area(),
       k.body({ isStatic: true }),
-      k.rect(w, h),
       k.color(120, 100, 120),
       "cplatform",
       { armed: true },

--- a/src/scenes/LevelSelect.ts
+++ b/src/scenes/LevelSelect.ts
@@ -5,9 +5,9 @@ function levelButton(label: string, x: number, y: number, onPress: () => void) {
     k.rect(160, 40),
     k.pos(x, y),
     k.color(60, 60, 90),
+    k.anchor("center"),
     k.area(),
     k.outline(2, k.rgb(200, 200, 220)),
-    k.anchor("center"),
   ]);
   btn.add([k.text(label, { size: 16 }), k.anchor("center")]);
 

--- a/src/scenes/level1.ts
+++ b/src/scenes/level1.ts
@@ -24,23 +24,25 @@ export default function level1() {
   });
 
   // Helpers
-  const solid = (x: number, y: number, w: number, h: number, color = k.rgb(120, 80, 160)) => k.add([
-    k.pos(x, y),
-    k.area(),
-    k.body({ isStatic: true }),
-    k.color(color.r, color.g, color.b),
-    k.rect(w, h),
-    "solid",
-  ]);
+  const solid = (x: number, y: number, w: number, h: number, color = k.rgb(120, 80, 160)) =>
+    k.add([
+      k.pos(x, y),
+      k.rect(w, h),
+      k.area(),
+      k.body({ isStatic: true }),
+      k.color(color.r, color.g, color.b),
+      "solid",
+    ]);
 
-  const hazard = (x: number, y: number, w: number, h: number) => k.add([
-    k.pos(x, y),
-    k.area(),
-    k.body({ isStatic: true }),
-    k.color(200, 70, 70),
-    k.rect(w, h),
-    "hazard",
-  ]);
+  const hazard = (x: number, y: number, w: number, h: number) =>
+    k.add([
+      k.pos(x, y),
+      k.rect(w, h),
+      k.area(),
+      k.body({ isStatic: true }),
+      k.color(200, 70, 70),
+      "hazard",
+    ]);
 
   // Level layout
   solid(120, 200, 420, 24);        // left floor
@@ -51,9 +53,9 @@ export default function level1() {
   // Moving platform
   const mplat = k.add([
     k.pos(520, 150),
+    k.rect(60, 10),
     k.area(),
     k.body({ isStatic: true }),
-    k.rect(60, 10),
     k.color(100, 100, 140),
     "solid",
     "mplatform",
@@ -66,20 +68,21 @@ export default function level1() {
   });
 
   // Coins guiding jump arc
-  const coin = (x: number, y: number) => k.add([
-    k.pos(x, y),
-    k.area(),
-    k.circle(4),
-    k.color(255, 220, 0),
-    "coin",
-  ]);
+  const coin = (x: number, y: number) =>
+    k.add([
+      k.pos(x, y),
+      k.circle(4),
+      k.area(),
+      k.color(255, 220, 0),
+      "coin",
+    ]);
   [420, 455, 490, 625].forEach((x, i) => coin(x, 90 + (i % 2 ? -6 : 0)));
 
   // Exit door
   k.add([
     k.pos(940, 176),
-    k.area(),
     k.rect(16, 24),
+    k.area(),
     k.color(160, 160, 200),
     "exit",
   ]);
@@ -88,8 +91,8 @@ export default function level1() {
   let respawn = spawn.clone();
   k.add([
     k.pos(700, 176),
-    k.area(),
     k.rect(8, 16),
+    k.area(),
     k.color(80, 200, 120),
     "checkpoint",
   ]);

--- a/src/systems/player.ts
+++ b/src/systems/player.ts
@@ -10,11 +10,11 @@ export function spawnPlayer(p = k.vec2(64, 0)) {
 
   const plr = k.add([
     k.pos(p.x, p.y - 1),
-    k.area(),
     k.anchor("center"),
+    k.rect(14, 16),
+    k.area(),
     k.body({ jumpForce: JUMP }),   // default jump force
     k.color(230, 230, 255),
-    k.rect(14, 16),
     k.opacity(1),                  // for flash()
     { hearts },
   ]);


### PR DESCRIPTION
## Summary
- Ensure player collider uses correct shape by defining rect before area
- Update level helper functions so solids and hazards have proper physics bodies
- Align button anchoring before area for consistent UI collisions

## Testing
- `npm test` *(fails: Missing script "test")*
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_b_68977f9a0be48320a9cd7185e93c289f