### PR TITLE
Spawn player above platform to drop onto it

### DIFF
--- a/src/entities/player.ts
+++ b/src/entities/player.ts
@@ -3,6 +3,10 @@ import type { Vec2, Key } from "kaboom";
 
 export type Player = ReturnType<typeof spawnPlayer>;
 
+// Y offset so the player starts slightly above the spawn point and
+// drops down onto the platform instead of appearing inside it.
+export const SPAWN_Y_OFFSET = 24;
+
 export function spawnPlayer(p: Vec2 = k.vec2(64, 0)) {
   const SPEED = 220;
   const JUMP = 420;
@@ -16,7 +20,9 @@ export function spawnPlayer(p: Vec2 = k.vec2(64, 0)) {
   let iFrames = 0;
 
   const plr = k.add([
-    k.pos(p.x, p.y - 1),
+    // Start above the provided position so gravity can settle the
+    // character naturally on the platform.
+    k.pos(p.x, p.y - SPAWN_Y_OFFSET),
     k.anchor("center"),
     k.rect(14, 16),
     k.area(),

--- a/src/scenes/level1.ts
+++ b/src/scenes/level1.ts
@@ -1,5 +1,5 @@
 import { k } from "../game";
-import { spawnPlayer } from "../entities/player";
+import { spawnPlayer, SPAWN_Y_OFFSET } from "../entities/player";
 
 export default function level1() {
   k.setGravity(1200);
@@ -127,7 +127,7 @@ export default function level1() {
   k.onUpdate(() => {
     if ((plr as any).getHearts?.() === 0) {
       k.wait(0.05, () => {
-        plr.pos = respawn.clone();
+        plr.pos = respawn.clone().sub(k.vec2(0, SPAWN_Y_OFFSET));
         (plr as any).hearts = 3;
         plr.vel = k.vec2(0, 0);
       });

--- a/src/scenes/level1_long.ts
+++ b/src/scenes/level1_long.ts
@@ -1,5 +1,5 @@
 import { k } from "../game";
-import { spawnPlayer } from "../entities/player";
+import { spawnPlayer, SPAWN_Y_OFFSET } from "../entities/player";
 import { solid, hazard, coin, checkpoint, exitDoor, movingPlatform, collapsingPlatform } from "../level/kit";
 import { spawnPatroller } from "../entities/enemy";
 
@@ -153,7 +153,7 @@ export default function level1_long() {
     const hearts = (plr as any).getHearts?.() ?? 3;
     if (hearts <= 0) {
       k.wait(0.05, () => {
-        plr.pos = respawn.clone();
+        plr.pos = respawn.clone().sub(k.vec2(0, SPAWN_Y_OFFSET));
         (plr as any).hearts = 3;
         plr.vel = k.vec2(0, 0);
       });


### PR DESCRIPTION
## Summary
- spawn the player slightly above the requested position so gravity settles them on the platform
- use the same offset on respawn in both levels to prevent spawning inside terrain

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Permission denied: vite)


------
https://chatgpt.com/codex/tasks/task_b_68979de57af083209a2761cae07c8b65