### PR TITLE
feat: robust asset loading

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,76 +1,62 @@
 import { k } from "./game";
 
 export const SPRITES = {
-  player: {
-    url: "/sprites/player.png",
-    sliceX: 8,
-    sliceY: 1,
-    anims: {
-      idle: { from: 0, to: 1, speed: 6, loop: true },
-      run:  { from: 2, to: 5, speed: 12, loop: true },
-      jump: 6,
-      fall: 7,
-      hurt: 6, // reuse jump for now
-    },
-    // if your sprite faces right by default, we’ll flipX for left movement
-  },
-  enemy_slime: {
-    url: "/sprites/enemy_slime.png",
-    sliceX: 4,
-    sliceY: 1,
-    anims: {
-      walk: { from: 0, to: 3, speed: 8, loop: true },
-    },
-  },
-  coin: {
-    url: "/sprites/coin.png",
-    sliceX: 6,
-    sliceY: 1,
-    anims: {
-      spin: { from: 0, to: 5, speed: 12, loop: true },
-    },
-  },
-  checkpoint: {
-    url: "/sprites/checkpoint.png",
-    sliceX: 2,
-    sliceY: 1,
-    anims: { idle: { from: 0, to: 1, speed: 4, loop: true } },
-  },
-  door: {
-    url: "/sprites/door.png",
-    sliceX: 1,
-    sliceY: 1,
-    anims: { idle: 0 },
-  },
+  player:       { url: "/sprites/player.png",      sliceX: 8, sliceY: 1, anims: { idle:{from:0,to:1,speed:6,loop:true}, run:{from:2,to:5,speed:12,loop:true}, jump:6, fall:7, hurt:6 } },
+  enemy_slime:  { url: "/sprites/enemy_slime.png", sliceX: 4, sliceY: 1, anims: { walk:{from:0,to:3,speed:8,loop:true} } },
+  coin:         { url: "/sprites/coin.png",        sliceX: 6, sliceY: 1, anims: { spin:{from:0,to:5,speed:12,loop:true} } },
+  checkpoint:   { url: "/sprites/checkpoint.png",  sliceX: 2, sliceY: 1, anims: { idle:{from:0,to:1,speed:4,loop:true} } },
+  door:         { url: "/sprites/door.png",        sliceX: 1, sliceY: 1, anims: { idle:0 } },
+};
+
+export const SOUNDS = {
+  jump: "/audio/jump.ogg",
+  coin: "/audio/coin.ogg",
+  hit: "/audio/hit.ogg",
+  checkpoint: "/audio/checkpoint.ogg",
+  exit: "/audio/exit.ogg",
+  bg_level1: "/audio/bg_level1.ogg",
 };
 
 let loaded = false;
 
+function tinyDataURL(hex = "#fff"): string {
+  const c = document.createElement("canvas");
+  c.width = 2; c.height = 2;
+  const ctx = c.getContext("2d")!;
+  ctx.fillStyle = hex; ctx.fillRect(0, 0, 2, 2);
+  return c.toDataURL();
+}
+
+async function urlExists(url: string): Promise<boolean> {
+  try {
+    await new Promise<void>((res, rej) => {
+      const img = new Image();
+      img.onload = () => res();
+      img.onerror = () => rej(new Error("img error"));
+      img.src = url;
+    });
+    return true;
+  } catch { return false; }
+}
+
 export async function loadAssets() {
   if (loaded) return;
-  // Load each sprite; tolerate missing files during early prototyping.
-  await Promise.all(
-    Object.entries(SPRITES).map(async ([name, cfg]) => {
-      const opts = {
-        sliceX: (cfg as any).sliceX,
-        sliceY: (cfg as any).sliceY,
-        anims:  (cfg as any).anims,
-      } as any;
-      try {
-        // Check if the resource actually exists before asking kaboom to load it.
-        const res = await fetch((cfg as any).url);
-        if (!res.ok) throw new Error("missing");
-        await k.loadSprite(name, (cfg as any).url, opts);
-      } catch {
-        // Fallback: create a tiny placeholder to avoid rejected load promises
-        console.warn(`[assets] Using placeholder for ${name}`);
-        const canvas = document.createElement("canvas");
-        canvas.width = 2; canvas.height = 2;
-        const ctx = canvas.getContext("2d")!;
-        ctx.fillStyle = "#fff"; ctx.fillRect(0,0,2,2);
-        await k.loadSprite(name, canvas.toDataURL(), opts);
-      }
-    })
-  );
+
+  // Sprites
+  for (const [name, cfg] of Object.entries(SPRITES)) {
+    const ok = await urlExists((cfg as any).url);
+    const source = ok ? (cfg as any).url : tinyDataURL("#bbb");
+    await k.loadSprite(name, source, {
+      sliceX: (cfg as any).sliceX,
+      sliceY: (cfg as any).sliceY,
+      anims:  (cfg as any).anims,
+    });
+  }
+
+  // Sounds
+  for (const [name, url] of Object.entries(SOUNDS)) {
+    try { await k.loadSound(name, url as string); } catch { /* ignore */ }
+  }
+
   loaded = true;
 }


### PR DESCRIPTION
## Summary
- add placeholder generation and URL existence check for sprites
- fall back to tiny data URL when sprites are missing
- gracefully load sounds, ignoring missing files

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689894bbe8788320bc355f73b2527c6d