### PR TITLE
feat: generate placeholder sprites for missing assets

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,12 +1,21 @@
 import { k } from "./game";
 
+/**
+ * Edit URLs later when you add real art. The generator will create
+ * colored placeholder sheets for any missing file automatically.
+ */
 export const SPRITES = {
-  player:       { url: "/sprites/player.png",      sliceX: 8, sliceY: 1, anims: { idle:{from:0,to:1,speed:6,loop:true}, run:{from:2,to:5,speed:12,loop:true}, jump:6, fall:7, hurt:6 } },
-  enemy_slime:  { url: "/sprites/enemy_slime.png", sliceX: 4, sliceY: 1, anims: { walk:{from:0,to:3,speed:8,loop:true} } },
-  coin:         { url: "/sprites/coin.png",        sliceX: 6, sliceY: 1, anims: { spin:{from:0,to:5,speed:12,loop:true} } },
-  checkpoint:   { url: "/sprites/checkpoint.png",  sliceX: 2, sliceY: 1, anims: { idle:{from:0,to:1,speed:4,loop:true} } },
-  door:         { url: "/sprites/door.png",        sliceX: 1, sliceY: 1, anims: { idle:0 } },
-};
+  player:       { url: "/sprites/player.png",      sliceX: 8, sliceY: 1, frameW: 16, frameH: 16,
+                  anims: { idle:{from:0,to:1,speed:6,loop:true}, run:{from:2,to:5,speed:12,loop:true}, jump:6, fall:7, hurt:6 } },
+  enemy_slime:  { url: "/sprites/enemy_slime.png", sliceX: 4, sliceY: 1, frameW: 14, frameH: 12,
+                  anims: { walk:{from:0,to:3,speed:8,loop:true} } },
+  coin:         { url: "/sprites/coin.png",        sliceX: 6, sliceY: 1, frameW: 10, frameH: 10,
+                  anims: { spin:{from:0,to:5,speed:12,loop:true} } },
+  checkpoint:   { url: "/sprites/checkpoint.png",  sliceX: 2, sliceY: 1, frameW: 8,  frameH: 16,
+                  anims: { idle:{from:0,to:1,speed:4,loop:true} } },
+  door:         { url: "/sprites/door.png",        sliceX: 1, sliceY: 1, frameW: 16, frameH: 24,
+                  anims: { idle:0 } },
+} as const;
 
 export const SOUNDS = {
   jump: "/audio/jump.ogg",
@@ -19,14 +28,7 @@ export const SOUNDS = {
 
 let loaded = false;
 
-function tinyDataURL(hex = "#fff"): string {
-  const c = document.createElement("canvas");
-  c.width = 2; c.height = 2;
-  const ctx = c.getContext("2d")!;
-  ctx.fillStyle = hex; ctx.fillRect(0, 0, 2, 2);
-  return c.toDataURL();
-}
-
+/** Probe an image URL without throwing. */
 async function urlExists(url: string): Promise<boolean> {
   try {
     await new Promise<void>((res, rej) => {
@@ -39,24 +41,67 @@ async function urlExists(url: string): Promise<boolean> {
   } catch { return false; }
 }
 
+/** Generate a sprite sheet canvas (sliceX × sliceY) with distinct frame colors & a subtle grid. */
+function makePlaceholderSheet(
+  sliceX: number,
+  sliceY: number,
+  frameW = 16,
+  frameH = 16,
+  baseHue = 210, // vary per sprite if you want
+): string {
+  const w = sliceX * frameW;
+  const h = sliceY * frameH;
+  const c = document.createElement("canvas");
+  c.width = w; c.height = h;
+  const ctx = c.getContext("2d")!;
+
+  // Draw frames
+  let hue = baseHue;
+  for (let y = 0; y < sliceY; y++) {
+    for (let x = 0; x < sliceX; x++) {
+      hue = (hue + 23) % 360;
+      ctx.fillStyle = `hsl(${hue} 40% 55%)`;
+      ctx.fillRect(x * frameW, y * frameH, frameW, frameH);
+
+      // inner accent
+      ctx.fillStyle = `hsl(${(hue + 180) % 360} 50% 65%)`;
+      ctx.fillRect(x * frameW + 2, y * frameH + 2, frameW - 4, frameH - 4);
+
+      // grid lines
+      ctx.strokeStyle = "rgba(0,0,0,0.25)";
+      ctx.strokeRect(x * frameW + 0.5, y * frameH + 0.5, frameW - 1, frameH - 1);
+    }
+  }
+  return c.toDataURL("image/png");
+}
+
 export async function loadAssets() {
   if (loaded) return;
 
-  // Sprites
+  // ---- Sprites: probe -> load real or generated sheet ----
   for (const [name, cfg] of Object.entries(SPRITES)) {
-    const ok = await urlExists((cfg as any).url);
-    const source = ok ? (cfg as any).url : tinyDataURL("#bbb");
-    await k.loadSprite(name, source, {
-      sliceX: (cfg as any).sliceX,
-      sliceY: (cfg as any).sliceY,
-      anims:  (cfg as any).anims,
-    });
+    const { url, sliceX, sliceY, frameW, frameH, anims } = cfg as any;
+
+    let source = url as string;
+    const ok = await urlExists(url);
+    if (!ok) {
+      // Choose a base hue per sprite name so they differ
+      const hueSeed = Math.abs(
+        Array.from(name).reduce((a, ch) => a + ch.charCodeAt(0), 0)
+      ) % 360;
+      source = makePlaceholderSheet(sliceX, sliceY, frameW, frameH, hueSeed);
+      console.warn(`[assets] Missing ${name} at ${url}. Using generated placeholder sheet.`);
+    }
+
+    await k.loadSprite(name, source, { sliceX, sliceY, anims });
   }
 
-  // Sounds
+  // ---- Sounds: load best‑effort; ignore failures ----
   for (const [name, url] of Object.entries(SOUNDS)) {
-    try { await k.loadSound(name, url as string); } catch { /* ignore */ }
+    try { await k.loadSound(name, url as string); }
+    catch { console.warn(`[assets] Sound not found: ${name} (${url}). Skipping.`); }
   }
 
   loaded = true;
 }
+


### PR DESCRIPTION
## Summary
- generate colored placeholder sprite sheets with subtle gridlines when sprite files are missing
- attempt to load sounds but skip missing audio files without crashing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_6898983ad54083208481556ead0b6bc2