### PR TITLE
Update deploy workflow to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,6 @@ permissions:
 
 jobs:
   deploy:
-    # For forked repositories, remove this condition to allow deployment
-    # if: github.repository == 'Barend183/Gavin-Adventure'
     runs-on: ubuntu-latest
     
     steps:
@@ -31,9 +29,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
       with:
-        # Use personal access token for forked repositories
-        # github_token: ${{ secrets.GITHUB_TOKEN }}
-        personal_token: ${{ secrets.GH_PAT }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: .
         publish_branch: gh-pages
         force_orphan: true


### PR DESCRIPTION
Replaces the use of a personal access token with GITHUB_TOKEN for deployment. Removes commented-out conditions and token configuration for forked repositories to simplify the workflow.